### PR TITLE
Miscellaneous improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
 .DS_Store
-target/classes/
-target/inject-tests/
-target/jenkins-for-test/
-target/rally-update-plugin-1.hpi
-target/rally-update-plugin-1.jar
-target/rally-update-plugin-1/
-target/surefire-reports/
-target/test-classes/
+target
+.idea
+**/*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>com.rallydev.rest</groupId>
 			<artifactId>rally-rest-api</artifactId>
-			<version>2.0.1</version>
+			<version>2.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/jenkins/plugins/rally/PostBuild.java
+++ b/src/main/java/com/jenkins/plugins/rally/PostBuild.java
@@ -5,27 +5,16 @@ import hudson.Launcher;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.Run;
 import hudson.scm.ChangeLogSet;
-import hudson.scm.ChangeLogSet.AffectedFile;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 
 import java.io.PrintStream;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import com.jenkins.plugins.rally.connector.RallyAttributes;
 import com.jenkins.plugins.rally.connector.RallyConnector;
 import com.jenkins.plugins.rally.connector.RallyDetailsDTO;
-import com.jenkins.plugins.rally.scm.BuildDetails;
 import com.jenkins.plugins.rally.scm.ChangeInformation;
 import com.jenkins.plugins.rally.scm.Changes;
 
@@ -37,7 +26,7 @@ import com.jenkins.plugins.rally.scm.Changes;
 public class PostBuild extends Builder {
 
 	private final String userName;
-	private final String password;
+	private final String apiKey;
 	private final String workspace;
 	private final String project;
 	private final String scmuri;
@@ -50,9 +39,9 @@ public class PostBuild extends Builder {
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public PostBuild(String userName, String password, String workspace, String project, String scmuri, String scmRepoName, String changesSince, String startDate, String endDate, String debugOn, String proxy) {
+    public PostBuild(String userName, String apiKey, String workspace, String project, String scmuri, String scmRepoName, String changesSince, String startDate, String endDate, String debugOn, String proxy) {
         this.userName = userName;
-        this.password = password;
+        this.apiKey = apiKey;
     	this.workspace = workspace;
     	this.project = project;
     	this.scmuri = scmuri;
@@ -73,7 +62,7 @@ public class PostBuild extends Builder {
     	RallyConnector rallyConnector = null;
     	boolean result;
     	try {
-    		rallyConnector = new RallyConnector(userName, password, workspace, project, scmuri, scmRepoName, proxy);
+    		rallyConnector = new RallyConnector(userName, apiKey, workspace, project, scmuri, scmRepoName, proxy);
 	        for(ChangeInformation ci : changes.getChangeInformation()) { //build level
 	        	try {
 		        	for(Object item : ci.getChangeLogSet().getItems()) { //each changes in above build
@@ -146,8 +135,8 @@ public class PostBuild extends Builder {
 		return userName;
 	}
 
-	public String getPassword() {
-		return password;
+	public String getApiKey() {
+		return apiKey;
 	}
 
 	public String getWorkspace() {

--- a/src/main/java/com/jenkins/plugins/rally/connector/RallyConnector.java
+++ b/src/main/java/com/jenkins/plugins/rally/connector/RallyConnector.java
@@ -47,10 +47,31 @@ public class RallyConnector {
     	restApi.setWsapiVersion(WSAPI_VERSION);
         restApi.setApplicationName(APPLICATION_NAME);
         if(proxy != null && proxy.trim().length() > 0){
-            restApi.setProxy(new URI(proxy));
+            initializeProxy(proxy);
         }
 	}
-	
+
+	private void initializeProxy(String proxy) throws URISyntaxException {
+		URI proxyUri = new URI(proxy);
+		String userInfo = proxyUri.getUserInfo();
+
+		if (userInfo != null && !userInfo.isEmpty()) {
+            if (userInfo.contains(":")) {
+                String[] tokens = userInfo.split(":");
+                if (tokens.length != 2) {
+                    throw new URISyntaxException(proxy, "The URI must have a userName and a apiKey (or neither)");
+                }
+                String username = tokens[0];
+                String passwd = tokens[1];
+                restApi.setProxy(proxyUri, username, passwd);
+            } else {
+                throw new URISyntaxException(proxy, "Unable to set userName on proxy URI without apiKey");
+            }
+        } else {
+            restApi.setProxy(proxyUri);
+        }
+	}
+
 	public void closeConnection() throws IOException {
 		restApi.close();
 	}

--- a/src/main/java/com/jenkins/plugins/rally/connector/RallyConnector.java
+++ b/src/main/java/com/jenkins/plugins/rally/connector/RallyConnector.java
@@ -1,7 +1,6 @@
 package com.jenkins.plugins.rally.connector;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -20,13 +19,10 @@ import com.rallydev.rest.response.Response;
 import com.rallydev.rest.response.UpdateResponse;
 import com.rallydev.rest.util.Fetch;
 import com.rallydev.rest.util.QueryFilter;
-import java.net.URI;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class RallyConnector {
 	private final String userName;
-	private final String password;
+	private final String apiKey;
 	private final String workspace;
 	private final String project;
 	private final String scmuri;
@@ -39,15 +35,15 @@ public class RallyConnector {
 	public static final String WSAPI_VERSION = "v2.0";
 	private String DEFAULT_REPO_NAME_CREATED_BY_PLUGIN = "plugin_repo";
 	
-	public RallyConnector(final String userName, final String password, final String workspace, final String project, final String scmuri, final String scmRepoName, final String proxy) throws URISyntaxException {
+	public RallyConnector(final String userName, final String apiKey, final String workspace, final String project, final String scmuri, final String scmRepoName, final String proxy) throws URISyntaxException {
 		this.userName = userName;
-        this.password = password;
+        this.apiKey = apiKey;
     	this.workspace = workspace;
     	this.project = project;
     	this.scmuri = scmuri;
     	this.scmRepoName = scmRepoName;
     	
-    	restApi = new RallyRestApi(new URI(RALLY_URL), userName, password);
+    	restApi = new RallyRestApi(new URI(RALLY_URL), apiKey);
     	restApi.setWsapiVersion(WSAPI_VERSION);
         restApi.setApplicationName(APPLICATION_NAME);
         if(proxy != null && proxy.trim().length() > 0){
@@ -227,7 +223,7 @@ public class RallyConnector {
 	
 	private String getAnyOtherRepoName(RallyDetailsDTO rdto) throws IOException {
 		QueryRequest scmRequest = new QueryRequest("SCMRepository");
-        scmRequest.setFetch(new Fetch("ObjectID","Name","Name"));        
+        scmRequest.setFetch(new Fetch("ObjectID", "Name", "Name"));
         scmRequest.setWorkspace(workspace);
         String anyOtherRepoName = "";
         try {

--- a/src/main/resources/com/jenkins/plugins/rally/PostBuild/config.jelly
+++ b/src/main/resources/com/jenkins/plugins/rally/PostBuild/config.jelly
@@ -6,7 +6,7 @@
   -->
 
   <f:entry title="Rally User Name" field="userName"><f:textbox /></f:entry>
-  <f:entry title="Rally Password" field="password"><f:password /></f:entry>
+  <f:entry title="API Key" field="apiKey"><f:password /></f:entry>
   <f:entry title="Rally Workspace" field="workspace"><f:textbox /></f:entry>
   <f:entry title="Rally Project" field="project"><f:textbox /> </f:entry>
   <f:entry title="SCM URI" field="scmuri"><f:textbox /> </f:entry>


### PR DESCRIPTION
This pull request includes the following:

* Update `.gitignore` to exclude target directory
* Added interpolating SCM URIs such that you can now specify something like:
    "http://github.com/username/project/commits/${revision}" for the SCM URI
    and the link in Rally will be what you expect
* Updated Rally Java library to 2.1.1
* Updated authentication to use API Tokens (instead of username/password,
    which is deprecated)
* Added better proxy support (can now supply proxy username/password)

I'm using this on my project and it's pretty fantastic. I'd love to hear any feedback.

This addresses the following issues logged in Jenkins's JIRA:

* [Add username/password to proxy configuration in Rally plugin](https://issues.jenkins-ci.org/browse/JENKINS-28362)
* [Add interpolation to SCM URL configuration in Rally plugin](https://issues.jenkins-ci.org/browse/JENKINS-28363)