### PR TITLE
modify RallyQueryBuilder.RallyQueryResponseObject.getTaskAttributeAsD…

### DIFF
--- a/src/main/java/com/jenkins/plugins/rally/utils/RallyQueryBuilder.java
+++ b/src/main/java/com/jenkins/plugins/rally/utils/RallyQueryBuilder.java
@@ -1,5 +1,7 @@
 package com.jenkins.plugins.rally.utils;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.jenkins.plugins.rally.RallyAssetNotFoundException;
 import com.jenkins.plugins.rally.RallyException;
@@ -20,7 +22,13 @@ public class RallyQueryBuilder {
         }
 
         public Double getTaskAttributeAsDouble(String attribute) {
-            return this.jsonObject.get(attribute).getAsDouble();
+            JsonElement jsonAttribute = this.jsonObject.get(attribute);
+
+            if (jsonAttribute == null || jsonAttribute.isJsonNull()) {
+                return 0.0d;
+            }
+
+            return jsonAttribute.getAsDouble();
         }
 
         public String getRef() {

--- a/src/test/java/com/jenkins/plugins/rally/utils/RallyQueryBuilderTest.java
+++ b/src/test/java/com/jenkins/plugins/rally/utils/RallyQueryBuilderTest.java
@@ -1,0 +1,48 @@
+package com.jenkins.plugins.rally.utils;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public final class RallyQueryBuilderTest {
+
+    final String stubAttribute = "NOT-THERE";
+    final double defaultDouble = 0.0d;
+
+
+    @Test
+    public void notDefinedTaskAttributeAsDoubleShouldFailSafelyToDefault() {
+        JsonObject fakeJsonObject = new JsonObject();
+        RallyQueryBuilder.RallyQueryResponseObject sut = new RallyQueryBuilder.RallyQueryResponseObject(fakeJsonObject);
+
+        double response = sut.getTaskAttributeAsDouble(stubAttribute);
+
+        assertThat(response, is(equalTo(defaultDouble)));
+    }
+
+    @Test
+    public void nullJsonTaskAttributeAsDoubleShouldFailSafelyToDefault() {
+        JsonObject fakeJsonObject = new JsonObject();
+        fakeJsonObject.add(stubAttribute, JsonNull.INSTANCE);
+        RallyQueryBuilder.RallyQueryResponseObject sut = new RallyQueryBuilder.RallyQueryResponseObject(fakeJsonObject);
+
+        double response = sut.getTaskAttributeAsDouble(stubAttribute);
+
+        assertThat(response, is(equalTo(defaultDouble)));
+    }
+
+    @Test
+    public void properTaskAttributeAsDoubleShouldReturnCorrectly() {
+        double properDouble = 1.1d;
+        JsonObject fakeJsonObject = new JsonObject();
+        fakeJsonObject.addProperty(stubAttribute, properDouble );
+        RallyQueryBuilder.RallyQueryResponseObject sut = new RallyQueryBuilder.RallyQueryResponseObject(fakeJsonObject);
+
+        double response = sut.getTaskAttributeAsDouble(stubAttribute);
+
+        assertThat(response, is(equalTo(properDouble)));
+    }
+}


### PR DESCRIPTION
modified RallyQueryBuilder.RallyQueryResponseObject.getTaskAttributeAsDouble to safely fail on null json.

https://groups.google.com/forum/#!msg/jenkinsci-users/xnSAT4fyo8Q/7j_az0xRAgAJ

simple workaround to set actuals to 0 but figured straight forward enough to submit a pr as well.