### PR TITLE
Compatibility with CVS to get Revisions

### DIFF
--- a/src/main/java/com/jenkins/plugins/rally/scm/JenkinsConnector.java
+++ b/src/main/java/com/jenkins/plugins/rally/scm/JenkinsConnector.java
@@ -133,8 +133,7 @@ public class JenkinsConnector implements ScmConnector {
 				try {
 					fileRevision = (String)fileClass.getDeclaredMethod("getRevision", new Class[] {}).invoke(files, null);
 				} catch (Exception e) {
-					out.println("ERROR " + e.getMessage());
-					e.printStackTrace();
+					e.printStackTrace(out);
 				}
             	filenameAndAction.filename = files.getPath() + " " + fileRevision;
             } else {

--- a/src/main/java/com/jenkins/plugins/rally/service/RallyService.java
+++ b/src/main/java/com/jenkins/plugins/rally/service/RallyService.java
@@ -111,30 +111,38 @@ public class RallyService implements AlmConnector {
         }
 
         for (RallyUpdateData.RallyId id : details.getIds()) {
+        	boolean anyChange = false;
+        	
             String storyRef = this.rallyConnector.queryForStory(id.getName());
             RallyQueryBuilder.RallyQueryResponseObject taskObject = getTaskObjectByStoryRef(details, storyRef);
 
             RallyUpdateBean updateInfo = new RallyUpdateBean();
 
-            updateInfo.setState(details.getTaskStatus().isEmpty()
-                    ? "In-Progress"
-                    : details.getTaskStatus());
+            if (!details.getTaskStatus().isEmpty()) {
+            	updateInfo.setState(details.getTaskStatus());
+            	anyChange = true;
+            }
 
             if (!details.getTaskToDO().isEmpty()) {
                 updateInfo.setTodo(details.getTaskToDO());
+                anyChange = true;
             }
 
             if (!details.getTaskActuals().isEmpty()) {
                 Double actuals = Double.parseDouble(details.getTaskActuals());
                 actuals = actuals + taskObject.getTaskAttributeAsDouble("Actuals");
                 updateInfo.setActual(Double.toString(actuals));
+                anyChange = true;
             }
 
             if (!details.getTaskEstimates().isEmpty()) {
                 updateInfo.setEstimate(details.getTaskEstimates());
+                anyChange = true;
             }
 
-            this.rallyConnector.updateTask(taskObject.getRef(), updateInfo);
+            if (anyChange) {
+            	this.rallyConnector.updateTask(taskObject.getRef(), updateInfo);
+            }
         }
     }
 

--- a/src/main/java/com/jenkins/plugins/rally/utils/RallyUpdateBean.java
+++ b/src/main/java/com/jenkins/plugins/rally/utils/RallyUpdateBean.java
@@ -27,7 +27,9 @@ public class RallyUpdateBean {
 
     public JsonObject getJsonObject() {
         JsonObject object = new JsonObject();
-        object.addProperty("State", state);
+        if (state != null) {
+        	object.addProperty("State", state);
+        }
 
         if (todo != null) {
             object.addProperty("ToDo", todo);


### PR DESCRIPTION
The current version of the plugin doesn't get files revision from CVS, I fixe this.

The other modification is about the fact that a developper can commit with only the taski. We don't want that the plugin change the state.